### PR TITLE
Clarify that scheduled publishing only happens if not already published

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,9 +10,12 @@ The aim of `contentful-scheduler` is to have developers setting up their Content
 entries for scheduled publishing.
 
 ## How does it work
-`contentful-scheduler` provides a web endpoint to receive webhook calls from Contentful,
-every time the endpoint recieves a call it looks for the value of the field defined in the configuration,
-if the value is a time in the future it will schedule the entry for publishing at the specified time.
+`contentful-scheduler` provides a web endpoint to receive webhook calls from Contentful.
+
+Every time the endpoint recieves a call it looks for the value of the field defined in the configuration.
+If the value is a time in the future -- and if the entry has not already been published -- it will schedule
+the entry for publishing at the specified time.
+
 A background worker based on the popular `resque` gem will then proceed to actually make the publish call
 against the Content Management API at the due time. For this the Entries you wish to publish require a
 customizable Date field, which we advice to call `publishDate`, this field can be configured inside your


### PR DESCRIPTION
Based on some user feedback, we should make sure it's clear that scheduled publishing only occurs if the entry has not already been published.