### PR TITLE
Remove unuseful success condition for unpublishing

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: ruby
 rvm:
-  - 2.2.3
   - 2.3.1
-  - 2.4.0
+  - 2.4.1
+  - 2.5.1
 before_install: gem install bundler -v 1.10.6

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 # CHANGELOG
 
 ## Unreleased
+### Changed
+* Removed unneeded success condition for unpublishing. [#15](https://github.com/contentful/contentful-scheduler.rb/issues/15)
 
 ## 0.5.0
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## Unreleased
 ### Changed
-* Removed unneeded success condition for unpublishing. [#15](https://github.com/contentful/contentful-scheduler.rb/issues/15)
+* If publish actions fail to enqueue, subsequent attempts to enqueue an unpublish action won't be logged as a failure. [#15](https://github.com/contentful/contentful-scheduler.rb/issues/15)
 
 ## 0.5.0
 ### Added

--- a/lib/contentful/scheduler/queue.rb
+++ b/lib/contentful/scheduler/queue.rb
@@ -20,7 +20,7 @@ module Contentful
         end
 
         if unpublishable?(webhook)
-          success = update_or_create_for_unpublish(webhook) && success
+          success = update_or_create_for_unpublish(webhook)
           log_event_success(webhook, success, 'unpublish', 'added to')
         end
       end
@@ -149,11 +149,11 @@ module Contentful
       end
 
       def webhook_publish_field?(webhook)
-        webhook.fields.key?(spaces.fetch(webhook.space_id, {})[:publish_field])
+        webhook.fields.key?(spaces.fetch(webhook.space_id, {})[:publish_field]) if webhook.respond_to?(:fields)
       end
 
       def webhook_unpublish_field?(webhook)
-        webhook.fields.key?(spaces.fetch(webhook.space_id, {})[:unpublish_field])
+        webhook.fields.key?(spaces.fetch(webhook.space_id, {})[:unpublish_field]) if webhook.respond_to?(:fields)
       end
 
       def webhook_publish_field(webhook)


### PR DESCRIPTION
Fixes #15 

There are 2 checks introduced when checking if the unpublish and publish date fields exists, because some of the webhook responses do not send fields, like for the unpublish event, and these are events that we still need to keep track of.